### PR TITLE
Add `serve` command that starts up the connector server 

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "author": "Karthikeyan Chinnakonda",
   "license": "ISC",
   "devDependencies": {
-    "@hasura/ndc-sdk-typescript": "^1.2.8",
+    "@hasura/ndc-sdk-typescript": "^4.2.0",
     "@types/node": "^20.11.17",
     "nodemon": "^3.0.3",
     "rimraf": "^5.0.5",

--- a/src/connector.ts
+++ b/src/connector.ts
@@ -1,0 +1,64 @@
+import * as sdk from "@hasura/ndc-sdk-typescript";
+import { Database } from "@azure/cosmos";
+import path from "node:path";
+
+export type Configuration = {
+    databaseClient: Database
+}
+
+export type State = {}
+
+
+export type ConnectorOptions = {
+    configFilePath: string
+}
+
+export function createConnector(options: ConnectorOptions): sdk.Connector<Configuration, State> {
+    const configFilePath = path.resolve(options.configFilePath);
+
+    const connector: sdk.Connector<Configuration, State> = {
+        parseConfiguration: async function(configurationDir: string): Promise<Configuration> {
+            throw new Error("Not implemented");
+        },
+
+        getCapabilities(configuration: Configuration): sdk.CapabilitiesResponse {
+            throw new Error("Not implemented");
+        },
+
+        tryInitState: async function(configuration: Configuration, metrics: unknown): Promise<State> {
+            throw new Error("Not implemented")
+        },
+
+        getSchema: async function(configuration: Configuration): Promise<sdk.SchemaResponse> {
+            throw new Error("Not implemented")
+        },
+
+        query: async function(configuration: Configuration, state: State, request: sdk.QueryRequest): Promise<sdk.QueryResponse> {
+            throw new Error("Not implemented")
+        },
+
+        mutation: async function(configuration: Configuration, state: State, request: sdk.MutationRequest): Promise<sdk.MutationResponse> {
+            throw new Error("Not implemented")
+        },
+
+        queryExplain: function(configuration: Configuration, state: State, request: sdk.QueryRequest): Promise<sdk.ExplainResponse> {
+            throw new Error("Function not implemented.");
+        },
+
+        mutationExplain: function(configuration: Configuration, state: State, request: sdk.MutationRequest): Promise<sdk.ExplainResponse> {
+            throw new Error("Function not implemented.");
+        },
+
+        healthCheck: async function(configuration: Configuration, state: State): Promise<undefined> {
+            return undefined;
+        },
+
+        fetchMetrics: async function(configuration: Configuration, state: State): Promise<undefined> {
+            return undefined;
+        },
+
+    }
+
+    return connector;
+
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,9 +25,9 @@
     // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
 
     /* Modules */
-    "module": "CommonJS",                                /* Specify what module code is generated. */
+    "module": "node16",                                /* Specify what module code is generated. */
     "rootDir": "./src",                                  /* Specify the root folder within your source files. */
-    "moduleResolution": "node",                          /* Specify how TypeScript looks up a file from a given module specifier. */
+    "moduleResolution": "node16",                          /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */


### PR DESCRIPTION
We need to add the `serve` command to start up the connector server. For now, all the functions present in the `sdk.Connector` can be "Not implemented". The plan going forward is to fill out those functions one by one.