### PR TITLE
Return `null` for a field when a field is undefined in a document row

### DIFF
--- a/src/sqlGeneration.ts
+++ b/src/sqlGeneration.ts
@@ -77,6 +77,8 @@ function formatSelectColumns(fieldsToSelect: SelectColumns, containerAlias: stri
     return Object.entries(fieldsToSelect).map(([alias, selectColumn]) => {
         switch (selectColumn.kind) {
             case 'column':
+                // `??` is the coalesce operator, we want the query to expicitly return
+                // a `null` value when a field is `undefined`.
                 return `${containerAlias}.${selectColumn.columnName} ?? null as ${alias}`
             case 'aggregate':
                 return `${selectColumn.aggregateFunction}(${containerAlias}.${selectColumn.columnName}) as ${alias}`


### PR DESCRIPTION
Earlier, if a document didn't contain a field `x` in some rows and existed in others, the NDC response would include the `x` field in the response only in the rows where it existed. This PR changes that to always include the `x` field and whenever it didn't exist, to use the `null` value instead.