### PR TITLE
Validate use of comparison operators and support missing comparison operators

### DIFF
--- a/src/schema.ts
+++ b/src/schema.ts
@@ -122,6 +122,270 @@ export enum BuiltInScalarTypeName {
     Integer = "Integer"
 }
 
+export type ScalarTypes = {
+    [k: string]: ScalarType;
+};
+
+export type ScalarOperatorMappings = {
+    [k: string]: string
+};
+
+export const scalarTypes: ScalarTypes = {
+    "Integer": {
+        aggregate_functions: {
+            "count": {
+                result_type: {
+                    type: "named",
+                    name: BuiltInScalarTypeName.Integer,
+                }
+            },
+            "sum": {
+                result_type: {
+                    type: "named",
+                    name: BuiltInScalarTypeName.Integer,
+                }
+            },
+            "avg": {
+                result_type: {
+                    type: "named",
+                    name: BuiltInScalarTypeName.Integer,
+                }
+            },
+            "min": {
+                result_type: {
+                    type: "named",
+                    name: BuiltInScalarTypeName.Integer,
+                }
+            },
+            "max": {
+                result_type: {
+                    type: "named",
+                    name: BuiltInScalarTypeName.Integer,
+                }
+            }
+        },
+        comparison_operators: {
+            eq: {
+                type: "equal"
+            },
+            neq: {
+                type: "custom",
+                argument_type: {
+                    type: "named",
+                    name: "Integer"
+                }
+            },
+            gt: {
+                type: "custom",
+                argument_type: {
+                    type: "named",
+                    name: "Integer"
+                }
+            },
+            lt: {
+                type: "custom",
+                argument_type: {
+                    type: "named",
+                    name: "Integer"
+                }
+            },
+            gte: {
+                type: "custom",
+                argument_type: {
+                    type: "named",
+                    name: "Integer"
+                }
+            },
+            lte: {
+                type: "custom",
+                argument_type: {
+                    type: "named",
+                    name: "Integer"
+                }
+            }
+        },
+    },
+    "Number": {
+        aggregate_functions: {
+            "count": {
+                result_type: {
+                    type: "named",
+                    name: BuiltInScalarTypeName.Number,
+                }
+            },
+            "sum": {
+                result_type: {
+                    type: "named",
+                    name: BuiltInScalarTypeName.Number,
+                }
+            },
+            "avg": {
+                result_type: {
+                    type: "named",
+                    name: BuiltInScalarTypeName.Number,
+                }
+            },
+            "min": {
+                result_type: {
+                    type: "named",
+                    name: BuiltInScalarTypeName.Number,
+                }
+            },
+            "max": {
+                result_type: {
+                    type: "named",
+                    name: BuiltInScalarTypeName.Number,
+                }
+            }
+        },
+        comparison_operators: {
+            eq: {
+                type: "equal"
+            },
+            neq: {
+                type: "custom",
+                argument_type: {
+                    type: "named",
+                    name: "Number"
+                }
+            },
+            gt: {
+                type: "custom",
+                argument_type: {
+                    type: "named",
+                    name: "Number"
+                }
+            },
+            lt: {
+                type: "custom",
+                argument_type: {
+                    type: "named",
+                    name: "Number"
+                }
+            },
+            gte: {
+                type: "custom",
+                argument_type: {
+                    type: "named",
+                    name: "Number"
+                }
+            },
+            lte: {
+                type: "custom",
+                argument_type: {
+                    type: "named",
+                    name: "Number"
+                }
+            }
+        },
+    },
+    "Boolean": {
+        aggregate_functions: {
+            "bool_and": {
+                result_type: {
+                    type: "named",
+                    name: BuiltInScalarTypeName.Boolean,
+                }
+            },
+            "bool_or": {
+                result_type: {
+                    type: "named",
+                    name: BuiltInScalarTypeName.Boolean,
+                }
+            },
+            "bool_not": {
+                result_type: {
+                    type: "named",
+                    name: BuiltInScalarTypeName.Boolean,
+                }
+            }
+        },
+        comparison_operators: {
+            eq: {
+                type: "equal"
+            },
+            neq: {
+                type: "custom",
+                argument_type: {
+                    type: "named",
+                    name: "Boolean"
+                }
+            }
+        },
+    },
+    "String": {
+        aggregate_functions: {},
+        comparison_operators: {
+            eq: {
+                type: "equal"
+            },
+            neq: {
+                type: "custom",
+                argument_type: {
+                    type: "named",
+                    name: "String"
+                }
+            },
+            gt: {
+                type: "custom",
+                argument_type: {
+                    type: "named",
+                    name: "String"
+                }
+            },
+            lt: {
+                type: "custom",
+                argument_type: {
+                    type: "named",
+                    name: "String"
+                }
+            },
+            gte: {
+                type: "custom",
+                argument_type: {
+                    type: "named",
+                    name: "String"
+                }
+            },
+            lte: {
+                type: "custom",
+                argument_type: {
+                    type: "named",
+                    name: "String"
+                }
+            },
+            contains: {
+                type: "custom",
+                argument_type: {
+                    type: "named",
+                    name: "String"
+                }
+            },
+            endswith: {
+                type: "custom",
+                argument_type: {
+                    type: "named",
+                    name: "String"
+                }
+            },
+            regexmatch: {
+                type: "custom",
+                argument_type: {
+                    type: "named",
+                    name: "String"
+                }
+            },
+            startswith: {
+                type: "custom",
+                argument_type: {
+                    type: "named",
+                    name: "String"
+                }
+            }
+        },
+    }
+};
+
 export function getJSONScalarTypes(): ScalarTypeDefinitions {
     var scalarTypeDefinitions: ScalarTypeDefinitions = {};
     scalarTypeDefinitions["Integer"] = {
@@ -179,264 +443,7 @@ export function getNdcSchemaResponse(collectionsSchema: CollectionsSchema): sdk.
         }
     });
 
-    type ScalarTypes = {
-        [k: string]: ScalarType;
-    };
-    const scalarTypes: ScalarTypes = {
-        "Integer": {
-            aggregate_functions: {
-                "count": {
-                    result_type: {
-                        type: "named",
-                        name: BuiltInScalarTypeName.Integer,
-                    }
-                },
-                "sum": {
-                    result_type: {
-                        type: "named",
-                        name: BuiltInScalarTypeName.Integer,
-                    }
-                },
-                "avg": {
-                    result_type: {
-                        type: "named",
-                        name: BuiltInScalarTypeName.Integer,
-                    }
-                },
-                "min": {
-                    result_type: {
-                        type: "named",
-                        name: BuiltInScalarTypeName.Integer,
-                    }
-                },
-                "max": {
-                    result_type: {
-                        type: "named",
-                        name: BuiltInScalarTypeName.Integer,
-                    }
-                }
-            },
-            comparison_operators: {
-                eq: {
-                    type: "equal"
-                },
-                neq: {
-                    type: "custom",
-                    argument_type: {
-                        type: "named",
-                        name: "Integer"
-                    }
-                },
-                gt: {
-                    type: "custom",
-                    argument_type: {
-                        type: "named",
-                        name: "Integer"
-                    }
-                },
-                lt: {
-                    type: "custom",
-                    argument_type: {
-                        type: "named",
-                        name: "Integer"
-                    }
-                },
-                gte: {
-                    type: "custom",
-                    argument_type: {
-                        type: "named",
-                        name: "Integer"
-                    }
-                },
-                lte: {
-                    type: "custom",
-                    argument_type: {
-                        type: "named",
-                        name: "Integer"
-                    }
-                }
-            },
-        },
-        "Number": {
-            aggregate_functions: {
-                "count": {
-                    result_type: {
-                        type: "named",
-                        name: BuiltInScalarTypeName.Number,
-                    }
-                },
-                "sum": {
-                    result_type: {
-                        type: "named",
-                        name: BuiltInScalarTypeName.Number,
-                    }
-                },
-                "avg": {
-                    result_type: {
-                        type: "named",
-                        name: BuiltInScalarTypeName.Number,
-                    }
-                },
-                "min": {
-                    result_type: {
-                        type: "named",
-                        name: BuiltInScalarTypeName.Number,
-                    }
-                },
-                "max": {
-                    result_type: {
-                        type: "named",
-                        name: BuiltInScalarTypeName.Number,
-                    }
-                }
-            },
-            comparison_operators: {
-                eq: {
-                    type: "equal"
-                },
-                neq: {
-                    type: "custom",
-                    argument_type: {
-                        type: "named",
-                        name: "Number"
-                    }
-                },
-                gt: {
-                    type: "custom",
-                    argument_type: {
-                        type: "named",
-                        name: "Number"
-                    }
-                },
-                lt: {
-                    type: "custom",
-                    argument_type: {
-                        type: "named",
-                        name: "Number"
-                    }
-                },
-                gte: {
-                    type: "custom",
-                    argument_type: {
-                        type: "named",
-                        name: "Number"
-                    }
-                },
-                lte: {
-                    type: "custom",
-                    argument_type: {
-                        type: "named",
-                        name: "Number"
-                    }
-                }
-            },
-        },
-        "Boolean": {
-            aggregate_functions: {
-                "bool_and": {
-                    result_type: {
-                        type: "named",
-                        name: BuiltInScalarTypeName.Boolean,
-                    }
-                },
-                "bool_or": {
-                    result_type: {
-                        type: "named",
-                        name: BuiltInScalarTypeName.Boolean,
-                    }
-                },
-                "bool_not": {
-                    result_type: {
-                        type: "named",
-                        name: BuiltInScalarTypeName.Boolean,
-                    }
-                }
-            },
-            comparison_operators: {
-                eq: {
-                    type: "equal"
-                },
-                neq: {
-                    type: "custom",
-                    argument_type: {
-                        type: "named",
-                        name: "Boolean"
-                    }
-                }
-            },
-        },
-        "String": {
-            aggregate_functions: {},
-            comparison_operators: {
-                eq: {
-                    type: "equal"
-                },
-                neq: {
-                    type: "custom",
-                    argument_type: {
-                        type: "named",
-                        name: "String"
-                    }
-                },
-                gt: {
-                    type: "custom",
-                    argument_type: {
-                        type: "named",
-                        name: "String"
-                    }
-                },
-                lt: {
-                    type: "custom",
-                    argument_type: {
-                        type: "named",
-                        name: "String"
-                    }
-                },
-                gte: {
-                    type: "custom",
-                    argument_type: {
-                        type: "named",
-                        name: "String"
-                    }
-                },
-                lte: {
-                    type: "custom",
-                    argument_type: {
-                        type: "named",
-                        name: "String"
-                    }
-                },
-                contains: {
-                    type: "custom",
-                    argument_type: {
-                        type: "named",
-                        name: "String"
-                    }
-                },
-                endswith: {
-                    type: "custom",
-                    argument_type: {
-                        type: "named",
-                        name: "String"
-                    }
-                },
-                regexmatch: {
-                    type: "custom",
-                    argument_type: {
-                        type: "named",
-                        name: "String"
-                    }
-                },
-                startswith: {
-                    type: "custom",
-                    argument_type: {
-                        type: "named",
-                        name: "String"
-                    }
-                }
-            },
-        }
-    };
+
 
     return {
         functions: [],

--- a/src/sqlGeneration.ts
+++ b/src/sqlGeneration.ts
@@ -75,18 +75,23 @@ export type SubqueryJoinClause = {
 
 export type JoinClause = ArrayJoinClause | SubqueryJoinClause;
 
-type ScalarDbOperator = {
+type ComparisonScalarDbOperator = {
     name: string,
     isInfix: boolean
+}
+
+type AggregateScalarDbOperator = {
+    operator: string,
+    resultType: string
 }
 
 // Defines how the NDC's scalar operators map to the DB operators
 type ScalarDBOperatorMappings = {
     comparison: {
-        [operatorName: string]: ScalarDbOperator
+        [operatorName: string]: ComparisonScalarDbOperator
     },
     aggregate?: {
-        [operatorName: string]: ScalarDbOperator
+        [operatorName: string]: AggregateScalarDbOperator
     } | undefined
 
 };
@@ -97,7 +102,6 @@ type ScalarOperatorMappings = {
 
 
 export const scalarComparisonOperatorMappings: ScalarOperatorMappings = {
-
     "Integer": {
         "comparison": {
             "eq": {
@@ -124,8 +128,29 @@ export const scalarComparisonOperatorMappings: ScalarOperatorMappings = {
                 "name": "<=",
                 "isInfix": true
             }
+        },
+        "aggregate": {
+            "count": {
+                "operator": "count",
+                "resultType": "Integer"
+            },
+            "sum": {
+                "operator": "sum",
+                "resultType": "Integer"
+            },
+            "avg": {
+                "operator": "sum",
+                "resultType": "Number"
+            },
+            "min": {
+                "operator": "sum",
+                "resultType": "Integer"
+            },
+            "max": {
+                "operator": "sum",
+                "resultType": "Integer"
+            },
         }
-
     },
     "Number": {
         "comparison": {
@@ -153,8 +178,29 @@ export const scalarComparisonOperatorMappings: ScalarOperatorMappings = {
                 "name": "<=",
                 "isInfix": true
             }
+        },
+        "aggregate": {
+            "count": {
+                "operator": "count",
+                "resultType": "Integer"
+            },
+            "sum": {
+                "operator": "sum",
+                "resultType": "Number"
+            },
+            "avg": {
+                "operator": "sum",
+                "resultType": "Number"
+            },
+            "min": {
+                "operator": "sum",
+                "resultType": "Number"
+            },
+            "max": {
+                "operator": "sum",
+                "resultType": "Number"
+            },
         }
-
     },
     "Boolean": {
         "comparison": {
@@ -166,6 +212,20 @@ export const scalarComparisonOperatorMappings: ScalarOperatorMappings = {
                 "name": "!=",
                 "isInfix": true
             }
+        },
+        "aggregate": {
+            "bool_and": {
+                "operator": "bool_and",
+                "resultType": "Boolean"
+            },
+            "bool_or": {
+                "operator": "bool_or",
+                "resultType": "Boolean"
+            },
+            "bool_not": {
+                "operator": "bool_or",
+                "resultType": "Boolean"
+            },
         }
 
     },
@@ -216,7 +276,7 @@ export const scalarComparisonOperatorMappings: ScalarOperatorMappings = {
     },
 };
 
-export function getDbComparisonOperator(scalarTypeName: string, operator: string): ScalarDbOperator {
+export function getDbComparisonOperator(scalarTypeName: string, operator: string): ComparisonScalarDbOperator {
     const scalarOperators = scalarComparisonOperatorMappings[scalarTypeName];
 
     if (scalarOperators === undefined && scalarOperators === null) {
@@ -287,7 +347,7 @@ export type Expression =
         type: "binary_comparison_operator";
         column: string;
         value: ComparisonValue;
-        dbOperator: ScalarDbOperator;
+        dbOperator: ComparisonScalarDbOperator;
     };
 
 


### PR DESCRIPTION
This PR adds validation of the usage of the operators within a predicate expression against the comparison target and also adds support for some of the operators we had published but gave errors on execution:

These operators are `STARTSWITH`, `ENDSWITH`, `CONTAINS` and `REGEXMATCH`.